### PR TITLE
feat(dx): create a CLI package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"test:watch": "turbo run test:watch"
 	},
 	"devDependencies": {
+		"@tnez-dev/cli": "workspace:*",
 		"@tnez-dev/config": "workspace:*",
 		"turbo": "latest"
 	},

--- a/packages/cli/.eslintrc.cjs
+++ b/packages/cli/.eslintrc.cjs
@@ -1,0 +1,3 @@
+const { node } = require('@tnez-dev/config/eslint')
+
+module.exports = node

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@tnez-dev/cli",
+	"version": "0.0.0",
+	"private": true,
+	"main": "dist/index.js",
+	"files": [
+		"dist"
+	],
+	"bin": {
+		"cli": "dist/index.js"
+	},
+	"scripts": {
+		"build": "tsc",
+		"clean": "rm -rf turbo && rm -rf node_modules",
+		"postinstall": "pnpm run build"
+	},
+	"dependencies": {
+		"clipanion": "3.2.0-rc.13",
+		"prompts": "^2.4.2"
+	},
+	"devDependencies": {
+		"@types/node": "^18.11.3",
+		"@types/prompts": "^2.4.1",
+		"ts-node": "^10.9.1",
+		"typescript": "^4.8.4"
+	}
+}

--- a/packages/cli/src/commands/hello.ts
+++ b/packages/cli/src/commands/hello.ts
@@ -1,0 +1,16 @@
+import { Command, Option } from 'clipanion'
+
+export class HelloCommand extends Command {
+	// The name of the command
+	static paths = [['hello']]
+	// The description of the command
+	static usage = {
+		description: 'Prints a greeting.',
+	}
+	// The options of the command
+	name = Option.String(`-n,--name`, { description: `Your name` })
+	// The main method of the command
+	async execute() {
+		this.context.stdout.write(`Hello, ${this.name}!\n`)
+	}
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,58 @@
+import { Command } from 'clipanion'
+import prompts from 'prompts'
+import { readFile, unlink, writeFile } from 'node:fs/promises'
+
+export class InitCommand extends Command {
+	static paths = [['init']]
+
+	static usage = {
+		description: 'Initialize a new project.',
+	}
+
+	async execute() {
+		const response = await prompts([
+			{
+				type: 'text',
+				name: 'projectName',
+				message: 'Choose a name for your project',
+			},
+			{
+				type: 'text',
+				name: 'projectDesc',
+				message: 'Provide a short description of your project',
+			},
+		])
+
+		this.context.stdout.write(`...initializing readme\n`)
+
+		await unlink('readme.md')
+		await writeFile(
+			'readme.md',
+			generateReadmeContent({
+				name: response.projectName,
+				desc: response.projectDesc,
+			}),
+		)
+
+		this.context.stdout.write(`...updating package.json\n`)
+		const packageJsonContents = await readFile('package.json', 'utf-8')
+		const newPackageJsonContents = packageJsonContents.replace(
+			/"name": "(.*)"/,
+			`"name": "${response.projectName}"`,
+		)
+		await writeFile('package.json', newPackageJsonContents, 'utf-8')
+
+		this.context.stdout.write(`...done 🎉\n`)
+	}
+}
+
+type GenerateReadeContentInput = {
+	name: string
+	desc: string
+}
+function generateReadmeContent({ name, desc }: GenerateReadeContentInput) {
+	return `# ${name}
+
+${desc}
+`
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,17 @@
+import { Cli } from 'clipanion'
+import { HelloCommand } from './commands/hello'
+import { InitCommand } from './commands/init'
+
+/* eslint-disable unicorn/prevent-abbreviations */
+const [node, app, ...args] = process.argv
+/* eslint-enable unicorn/prevent-abbreviations */
+
+const cli = new Cli({
+	binaryLabel: `tnez-dev: cli`,
+	binaryName: `${node} ${app}`,
+	binaryVersion: '0.0.0',
+})
+
+cli.register(HelloCommand)
+cli.register(InitCommand)
+cli.runExit(args)

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@tnez-dev/config/tsconfig/base.json",
+	"include": ["src/**/*.ts"],
+	"compilerOptions": {
+		"target": "ES2015",
+		"module": "commonjs",
+		"outDir": "dist"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,11 @@ importers:
 
   .:
     specifiers:
+      '@tnez-dev/cli': workspace:*
       '@tnez-dev/config': workspace:*
       turbo: latest
     devDependencies:
+      '@tnez-dev/cli': link:packages/cli
       '@tnez-dev/config': link:packages/config
       turbo: 1.6.1
 
@@ -31,6 +33,23 @@ importers:
       '@types/jest': 29.2.0
       jest: 29.2.1
       jest-mock-extended: 3.0.1_7yfpbkrrkkmtlepb2un4d37cti
+      typescript: 4.8.4
+
+  packages/cli:
+    specifiers:
+      '@types/node': ^18.11.3
+      '@types/prompts': ^2.4.1
+      clipanion: 3.2.0-rc.13
+      prompts: ^2.4.2
+      ts-node: ^10.9.1
+      typescript: ^4.8.4
+    dependencies:
+      clipanion: 3.2.0-rc.13
+      prompts: 2.4.2
+    devDependencies:
+      '@types/node': 18.11.3
+      '@types/prompts': 2.4.1
+      ts-node: 10.9.1_lw7q66ikwuedwcorwkk4v6trsa
       typescript: 4.8.4
 
   packages/config:
@@ -1120,6 +1139,12 @@ packages:
     resolution: {integrity: sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==}
     dev: true
 
+  /@types/prompts/2.4.1:
+    resolution: {integrity: sha512-1Mqzhzi9W5KlooNE4o0JwSXGUDeQXKldbGn9NO4tpxwZbHXYd+WcKpCksG2lbhH7U9I9LigfsdVsP2QAY0lNPA==}
+    dependencies:
+      '@types/node': 18.11.3
+    dev: true
+
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
@@ -1518,6 +1543,12 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
     dev: true
+
+  /clipanion/3.2.0-rc.13:
+    resolution: {integrity: sha512-JYuPIaZZOl4nTUP4BMXmHGxYkAD2gc0m5GxZKr2eKEjquyFj/WBbkERDesnUsQKewUmWvBzzxdbf8WQ/GBDduQ==}
+    dependencies:
+      typanion: 3.12.1
+    dev: false
 
   /cliui/8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -3189,7 +3220,6 @@ packages:
   /kleur/3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-    dev: true
 
   /language-subtag-registry/0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
@@ -3570,7 +3600,6 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-    dev: true
 
   /prop-types/15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3760,7 +3789,6 @@ packages:
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: true
 
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -4069,6 +4097,10 @@ packages:
       turbo-windows-64: 1.6.1
       turbo-windows-arm64: 1.6.1
     dev: true
+
+  /typanion/3.12.1:
+    resolution: {integrity: sha512-3SJF/czpzqq6G3lprGFLa6ps12yb1uQ1EmitNnep2fDMNh1aO/Zbq9sWY+3lem0zYb2oHJnQWyabTGUZ+L1ScQ==}
+    dev: false
 
   /type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}


### PR DESCRIPTION
This package can be invoked as `npx cli <command>` from the root of the repo. It will provide help with common tasks as needed.

Initially, we have created an `init` command that resets the repo to a state to start building a new project.
