### PR TITLE
refactor: remove all occurences of `@tnez-dev`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,3 @@
-const { base } = require('@tnez-dev/config/eslint')
+const { base } = require('config/eslint')
 
 module.exports = base

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,1 +1,1 @@
-module.exports = require('@tnez-dev/config/prettier')
+module.exports = require('config/prettier')

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tnez-dev/template",
+	"name": "template",
 	"version": "0.0.0",
 	"private": true,
 	"workspaces": [
@@ -18,8 +18,8 @@
 		"test:watch": "turbo run test:watch"
 	},
 	"devDependencies": {
-		"@tnez-dev/cli": "workspace:*",
-		"@tnez-dev/config": "workspace:*",
+		"cli": "workspace:*",
+		"config": "workspace:*",
 		"turbo": "latest"
 	},
 	"engines": {

--- a/packages/actions/jest.config.cjs
+++ b/packages/actions/jest.config.cjs
@@ -1,1 +1,1 @@
-module.exports = require('@tnez-dev/config/jest')
+module.exports = require('config/jest')

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tnez-dev/actions",
+	"name": "actions",
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
@@ -9,8 +9,8 @@
 		"test:watch": "jest --watch"
 	},
 	"dependencies": {
-		"@tnez-dev/effects": "workspace:*",
-		"@tnez-dev/utils": "workspace:*"
+		"effects": "workspace:*",
+		"utils": "workspace:*"
 	},
 	"devDependencies": {
 		"@jest/globals": "^29.2.1",

--- a/packages/actions/readme.md
+++ b/packages/actions/readme.md
@@ -1,4 +1,4 @@
-`@tnez-dev/actions`
+`actions`
 
 Actions are the core of the application. This is where we define our business-logic. We define things such as:
 
@@ -6,7 +6,7 @@ Actions are the core of the application. This is where we define our business-lo
 - `activateUser`
 - `cancelOrder`
 
-And how these things interact with the outside world via `@tnez-dev/effects`.
+And how these things interact with the outside world via `effects`.
 
 The purpose of separating business-logic into it's own package is so that we can test in isolation what **effects** a given **action** should take. In other words, given an **action** defined in a domain language common to the business, how should it **effect** the outside world.
 

--- a/packages/actions/src/examples/create-thing.test.ts
+++ b/packages/actions/src/examples/create-thing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { mockDeep } from 'jest-mock-extended'
-import { Data } from '@tnez-dev/effects'
+import { Data } from 'effects'
 import { createThing } from './create-thing'
 
 describe('createThing', () => {

--- a/packages/actions/src/examples/create-thing.ts
+++ b/packages/actions/src/examples/create-thing.ts
@@ -1,5 +1,5 @@
-import { safelyParseError } from '@tnez-dev/utils'
-import { Data } from '@tnez-dev/effects'
+import { safelyParseError } from 'utils'
+import { Data } from 'effects'
 import type { ActionInput, ActionOutput } from '../types'
 
 export type CreateThingEffects = {

--- a/packages/actions/tsconfig.json
+++ b/packages/actions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@tnez-dev/config/tsconfig/base.json",
+	"extends": "config/tsconfig/base.json",
 	"include": ["src/**/*.ts"],
 	"compilerOptions": {
 		"outDir": "dist"

--- a/packages/cli/.eslintrc.cjs
+++ b/packages/cli/.eslintrc.cjs
@@ -1,3 +1,3 @@
-const { node } = require('@tnez-dev/config/eslint')
+const { node } = require('config/eslint')
 
 module.exports = node

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tnez-dev/cli",
+	"name": "cli",
 	"version": "0.0.0",
 	"private": true,
 	"main": "dist/index.js",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@tnez-dev/config/tsconfig/base.json",
+	"extends": "config/tsconfig/base.json",
 	"include": ["src/**/*.ts"],
 	"compilerOptions": {
 		"target": "ES2015",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tnez-dev/config",
+	"name": "config",
 	"version": "0.0.0",
 	"private": true,
 	"exports": {

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tnez-dev/effects",
+	"name": "effects",
 	"version": "0.0.0",
 	"private": true,
 	"main": "src/index.ts",

--- a/packages/effects/readme.md
+++ b/packages/effects/readme.md
@@ -1,4 +1,4 @@
-`@tnez-dev/effects`
+`effects`
 
 **Effects** define how our applications interact with the outside world.
 

--- a/packages/effects/tsconfig.json
+++ b/packages/effects/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@tnez-dev/config/tsconfig/base.json",
+	"extends": "config/tsconfig/base.json",
 	"include": ["src/**/*.ts"],
 	"compilerOptions": {
 		"outDir": "dist"

--- a/packages/utils/jest.config.cjs
+++ b/packages/utils/jest.config.cjs
@@ -1,1 +1,1 @@
-module.exports = require('@tnez-dev/config/jest')
+module.exports = require('config/jest')

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tnez-dev/utils",
+	"name": "utils",
 	"version": "0.0.0",
 	"private": true,
 	"main": "src/index.ts",

--- a/packages/utils/readme.md
+++ b/packages/utils/readme.md
@@ -1,3 +1,3 @@
-`@tnez-dev/utils`
+`utils`
 
 Collection of utilities that are not specific to any individual package.

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@tnez-dev/config/tsconfig/base.json",
+	"extends": "config/tsconfig/base.json",
 	"include": ["src/**/*.ts"],
 	"compilerOptions": {
 		"outDir": "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,12 @@ importers:
 
   .:
     specifiers:
-      '@tnez-dev/cli': workspace:*
-      '@tnez-dev/config': workspace:*
+      'cli': workspace:*
+      'config': workspace:*
       turbo: latest
     devDependencies:
-      '@tnez-dev/cli': link:packages/cli
-      '@tnez-dev/config': link:packages/config
+      'cli': link:packages/cli
+      'config': link:packages/config
       turbo: 1.6.1
 
   packages/actions:
@@ -17,15 +17,15 @@ importers:
       '@jest/globals': ^29.2.1
       '@swc/core': ^1.3.10
       '@swc/jest': ^0.2.23
-      '@tnez-dev/effects': workspace:*
-      '@tnez-dev/utils': workspace:*
+      'effects': workspace:*
+      'utils': workspace:*
       '@types/jest': ^29.2.0
       jest: ^29.2.1
       jest-mock-extended: ^3.0.1
       typescript: ^4.8.4
     dependencies:
-      '@tnez-dev/effects': link:../effects
-      '@tnez-dev/utils': link:../utils
+      'effects': link:../effects
+      'utils': link:../utils
     devDependencies:
       '@jest/globals': 29.2.1
       '@swc/core': 1.3.10


### PR DESCRIPTION
In order to make this a better clean slate for starting projects, remove all the `@tnez-dev` references from the codebase.
