### PR TITLE
Defer transpilation to consuming `apps/*`

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   experimental: {
     appDir: true,
+    transpilePackages: ['actions'],
   },
 }
 

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -2,10 +2,9 @@
   "name": "actions",
   "version": "0.0.0",
   "private": true,
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "tsc",
     "check:lint": "eslint ./src --ext .ts",
     "check:types": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/packages/actions/src/pokemon/get-list.test.ts
+++ b/packages/actions/src/pokemon/get-list.test.ts
@@ -45,11 +45,9 @@ describe('happy path', () => {
       // Given...
       const effects = {
         external: {
-          fetch: jest
-            .fn()
-            .mockImplementationOnce(async () => ({
-              results: STUBBED_POKEMON_DATA,
-            })),
+          fetch: jest.fn().mockImplementationOnce(async () => ({
+            results: STUBBED_POKEMON_DATA,
+          })),
         },
       } as any
       const input = {}

--- a/packages/actions/src/pokemon/get-list.test.ts
+++ b/packages/actions/src/pokemon/get-list.test.ts
@@ -23,7 +23,7 @@ describe('happy path', () => {
         // Given...
         const effects = {
           external: {
-            fetch: jest.fn(),
+            fetch: jest.fn().mockImplementationOnce(async () => stubResponse()),
           },
         } as any
         const input = { limit: 10 }
@@ -32,10 +32,9 @@ describe('happy path', () => {
         await getList({ effects, input })
 
         // Then...
-        expect(effects.external.fetch).toHaveBeenCalledWith({
-          parseJson: true,
-          url: 'https://pokeapi.co/api/v2/pokemon?limit=10',
-        })
+        expect(effects.external.fetch).toHaveBeenCalledWith(
+          'https://pokeapi.co/api/v2/pokemon?limit=10',
+        )
       })
     })
   })
@@ -45,9 +44,7 @@ describe('happy path', () => {
       // Given...
       const effects = {
         external: {
-          fetch: jest.fn().mockImplementationOnce(async () => ({
-            results: STUBBED_POKEMON_DATA,
-          })),
+          fetch: jest.fn().mockImplementationOnce(async () => stubResponse()),
         },
       } as any
       const input = {}
@@ -63,3 +60,16 @@ describe('happy path', () => {
     })
   })
 })
+
+/**
+ * Helper to stub response object.
+ */
+function stubResponse(options: Partial<typeof Response> = {}) {
+  return {
+    json: async () => ({ results: STUBBED_POKEMON_DATA }),
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    ...options,
+  }
+}

--- a/packages/actions/src/pokemon/get-list.test.ts
+++ b/packages/actions/src/pokemon/get-list.test.ts
@@ -3,19 +3,16 @@ import { getList } from './get-list'
 
 const STUBBED_POKEMON_DATA = [
   {
-    id: 35,
     name: 'clefairy',
-    img: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/35.png',
+    url: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/35.png',
   },
   {
-    id: 42,
     name: 'golbat',
-    img: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/42.png',
+    url: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/42.png',
   },
   {
-    id: 57,
     name: 'primeape',
-    img: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/57.png',
+    url: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/57.png',
   },
 ]
 
@@ -50,7 +47,9 @@ describe('happy path', () => {
         external: {
           fetch: jest
             .fn()
-            .mockImplementationOnce(async () => STUBBED_POKEMON_DATA),
+            .mockImplementationOnce(async () => ({
+              results: STUBBED_POKEMON_DATA,
+            })),
         },
       } as any
       const input = {}

--- a/packages/actions/src/pokemon/get-list.ts
+++ b/packages/actions/src/pokemon/get-list.ts
@@ -1,6 +1,5 @@
 import * as z from 'zod'
-import { external } from 'effects'
-import { safelyParseError } from 'utils'
+import { parseResponse, safelyParseError } from 'utils'
 import { PokemonSchema } from './schema'
 import type { ActionInput, ActionOutput } from '../types'
 
@@ -24,16 +23,16 @@ export type PokemonGetListOutput = z.infer<typeof PokemonSchema>[]
  * What effects does this action need?
  */
 export type PokemonGetListRequiredEffects = {
-  external: typeof external
+  external: {
+    fetch: typeof fetch
+  }
 }
 
 /**
- * Configure the default effects for this action so that this work does not fall on the consumer.
+ * Configure the effects this action needs.
  */
-const configureEffects = () => ({
-  external: {
-    fetch: external.fetch,
-  },
+const configureEffects = (): PokemonGetListRequiredEffects => ({
+  external: { fetch },
 })
 
 const DEFAULT_INPUT = {
@@ -55,13 +54,12 @@ export async function getList({
   PokemonGetListInput
 >): ActionOutput<PokemonGetListOutput> {
   try {
-    const payload = await effects.external.fetch({
-      parseJson: true,
-      url: `https://pokeapi.co/api/v2/pokemon?limit=${
+    const response = await effects.external.fetch(
+      `https://pokeapi.co/api/v2/pokemon?limit=${
         input.limit ?? DEFAULT_INPUT.limit
       }`,
-    })
-
+    )
+    const payload = await parseResponse({ parseAs: 'json' })(response)
     const data = PayloadSchema.parse(payload).results
 
     return {

--- a/packages/actions/src/pokemon/get-list.ts
+++ b/packages/actions/src/pokemon/get-list.ts
@@ -61,7 +61,7 @@ export async function getList({
         input.limit ?? DEFAULT_INPUT.limit
       }`,
     })
-    console.log(payload)
+
     const data = PayloadSchema.parse(payload).results
 
     return {

--- a/packages/config/jest/index.cjs
+++ b/packages/config/jest/index.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  clearMocks: true,
   transform: {
     '^.+\\.ts$': ['@swc/jest'],
   },

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@prisma/client": "^4.5.0",
-    "node-fetch": "2",
+    "node-fetch": "^3.3.0",
     "utils": "workspace:*"
   }
 }

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@prisma/client": "^4.5.0",
-    "node-fetch": "^3.3.0",
     "utils": "workspace:*"
   }
 }

--- a/packages/effects/package.json
+++ b/packages/effects/package.json
@@ -2,10 +2,9 @@
   "name": "effects",
   "version": "0.0.0",
   "private": true,
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "tsc",
     "check:lint": "eslint ./src --ext .ts",
     "check:types": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/packages/effects/src/external/fetch.ts
+++ b/packages/effects/src/external/fetch.ts
@@ -1,22 +1,22 @@
-import * as nodeFetch from 'node-fetch'
+/// <reference lib="dom" />
+
 import { safelyParseError } from 'utils'
 
-export type FetchInput = nodeFetch.RequestInit & {
-  parseJson?: boolean
-  url: string
-}
+type Options = {
+  parseAsJson?: boolean
+} & Parameters<typeof fetch>[1]
 
-export async function fetch({ url, ...options }: FetchInput) {
-  const response = await nodeFetch.default(url, options)
+export async function fetchJson(url: string, options: Options = {}) {
+  const response = await fetch(url, options)
 
   if (!response.ok) {
     throw new Error(`Fetch failed: ${response.status} ${response.statusText}`)
   }
 
-  return options.parseJson ? await parseJson(response) : await response.text()
+  return options.parseAsJson ? await parseJson(response) : await response.text()
 }
 
-async function parseJson(response: nodeFetch.Response) {
+async function parseJson(response: Response) {
   try {
     return await response.json()
   } catch (error: unknown) {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,10 +2,9 @@
   "name": "utils",
   "version": "0.0.0",
   "private": true,
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "tsc",
     "check:lint": "eslint ./src --ext .ts",
     "check:types": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,1 +1,2 @@
+export * from './parse-response'
 export * from './safely-parse-error'

--- a/packages/utils/src/parse-response.test.ts
+++ b/packages/utils/src/parse-response.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { parseResponse } from './parse-response'
+
+describe('when response.ok is false', () => {
+  it('should throw expected error', async () => {
+    const response = stubResponse({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    })
+    const parse = parseResponse()
+
+    return expect(parse(response)).rejects.toThrow(
+      'Fetch failed with 500 Internal Server Error',
+    )
+  })
+})
+
+describe('when response.ok is true', () => {
+  describe('and { parseAs: `text` }', () => {
+    it('should call response.text()', async () => {
+      const response = stubResponse()
+      const parse = parseResponse({ parseAs: 'text' })
+
+      await parse(response)
+
+      expect(response.text).toHaveBeenCalled()
+    })
+  })
+
+  describe('and { parseAs: `json` }', () => {
+    it('should call response.json()', async () => {
+      const response = stubResponse()
+      const parse = parseResponse({ parseAs: 'json' })
+
+      await parse(response)
+
+      expect(response.json).toHaveBeenCalled()
+    })
+  })
+})
+
+/**
+ * Helper function to stub a Response object.
+ */
+function stubResponse(options: any = {}) {
+  return {
+    ok: true,
+    json: jest.fn(),
+    status: 200,
+    statusText: 'OK',
+    text: jest.fn(),
+    ...options,
+  } as Response
+}

--- a/packages/utils/src/parse-response.ts
+++ b/packages/utils/src/parse-response.ts
@@ -1,0 +1,33 @@
+/// <reference lib="dom" />
+
+import { safelyParseError } from './safely-parse-error'
+
+type Options = {
+  /**
+   * If provided, the response will be parsed as either JSON or text.
+   * If not provided, the response will be returned as-is.
+   */
+  parseAs?: 'json' | 'text'
+}
+
+/**
+ * Configure a response parser for a fetch request will perform some basic error handling and parsing of the response object.
+ */
+export function parseResponse(options: Options | undefined = {}) {
+  return async (response: Response) => {
+    try {
+      if (!response.ok) {
+        throw new Error(
+          `Fetch failed with ${response.status} ${response.statusText}`,
+        )
+      }
+
+      return options.parseAs === undefined
+        ? response
+        : response[options.parseAs]()
+    } catch (error: unknown) {
+      const { message } = safelyParseError(error)
+      throw new Error(`Failed to parse response: ${message}`)
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,14 +166,12 @@ importers:
       '@types/node': ^18.11.3
       '@types/node-fetch': '2'
       config: workspace:*
-      node-fetch: ^3.3.0
       prisma: ^4.5.0
       ts-node: ^10.9.1
       typescript: ^4.8.4
       utils: workspace:*
     dependencies:
       '@prisma/client': 4.5.0_prisma@4.5.0
-      node-fetch: 3.3.0
       utils: link:../utils
     devDependencies:
       '@types/node': 18.11.3
@@ -2282,11 +2280,6 @@ packages:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
 
-  /data-uri-to-buffer/4.0.0:
-    resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
-    engines: {node: '>= 12'}
-    dev: false
-
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -2922,14 +2915,6 @@ packages:
       bser: 2.1.1
     dev: true
 
-  /fetch-blob/3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.2.1
-    dev: false
-
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2984,13 +2969,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-
-  /formdata-polyfill/4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
-    dependencies:
-      fetch-blob: 3.2.0
-    dev: false
 
   /fraction.js/4.2.0:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
@@ -4313,11 +4291,6 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /node-domexception/1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    dev: false
-
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -4328,15 +4301,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: false
-
-  /node-fetch/3.3.0:
-    resolution: {integrity: sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      data-uri-to-buffer: 4.0.0
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
     dev: false
 
   /node-int64/0.4.0:
@@ -5486,11 +5450,6 @@ packages:
     dependencies:
       makeerror: 1.0.12
     dev: true
-
-  /web-streams-polyfill/3.2.1:
-    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
-    engines: {node: '>= 8'}
-    dev: false
 
   /webcrypto-core/1.7.5:
     resolution: {integrity: sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,14 +166,14 @@ importers:
       '@types/node': ^18.11.3
       '@types/node-fetch': '2'
       config: workspace:*
-      node-fetch: '2'
+      node-fetch: ^3.3.0
       prisma: ^4.5.0
       ts-node: ^10.9.1
       typescript: ^4.8.4
       utils: workspace:*
     dependencies:
       '@prisma/client': 4.5.0_prisma@4.5.0
-      node-fetch: 2.6.7
+      node-fetch: 3.3.0
       utils: link:../utils
     devDependencies:
       '@types/node': 18.11.3
@@ -2282,6 +2282,11 @@ packages:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
 
+  /data-uri-to-buffer/4.0.0:
+    resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
+    engines: {node: '>= 12'}
+    dev: false
+
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -2917,6 +2922,14 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fetch-blob/3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
+    dev: false
+
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2971,6 +2984,13 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  /formdata-polyfill/4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
+    dev: false
 
   /fraction.js/4.2.0:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
@@ -4293,6 +4313,11 @@ packages:
       tslib: 2.4.0
     dev: false
 
+  /node-domexception/1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: false
+
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -4303,6 +4328,15 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: false
+
+  /node-fetch/3.3.0:
+    resolution: {integrity: sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.0
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
     dev: false
 
   /node-int64/0.4.0:
@@ -5452,6 +5486,11 @@ packages:
     dependencies:
       makeerror: 1.0.12
     dev: true
+
+  /web-streams-polyfill/3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
+    dev: false
 
   /webcrypto-core/1.7.5:
     resolution: {integrity: sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==}

--- a/turbo.json
+++ b/turbo.json
@@ -15,19 +15,17 @@
       "outputs": []
     },
     "dev": {
-      "cache": false,
-      "dependsOn": ["utils#build", "effects#build", "actions#build"]
+      "cache": false
     },
     "clean": {
       "cache": false
     },
     "test": {
-      "outputs": [],
-      "dependsOn": ["utils#build", "effects#build", "actions#build"]
+      "outputs": []
     },
     "test:watch": {
       "cache": false,
-      "dependsOn": ["utils#build", "effects#build", "actions#build"]
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
Remove build / transpilation step from all packages except for `packages/cli`. For the rest, defer the transpilation to the consuming packages so that they can choose the best method.

This simplifies development of packages and also let's us choose the right deliver method for each application.
